### PR TITLE
Add ignore_missing option to DataclassArchiver

### DIFF
--- a/bpylist/archive_types.py
+++ b/bpylist/archive_types.py
@@ -8,7 +8,13 @@ class Error(Exception):
     pass
 
 
+_IGNORE_UNMAPPED_KEY = "__bpylist_ignore_unmapped__"
+
+
 def _verify_dataclass_has_fields(dataclass, plist_obj):
+    if getattr(dataclass, _IGNORE_UNMAPPED_KEY, False):
+        return
+
     dataclass_fields = dataclasses.fields(dataclass)
 
     skip_fields = {'$class'}
@@ -42,7 +48,17 @@ class DataclassArchiver:
             {'MyObjType': MyObjType }
     )
 
+    If you are only interested in certain fields, you can ignore unmapped
+    fields, so that no exception is raised:
+
+    @dataclasses.dataclass
+    class MyObjType(DataclassArchiver, ignore_unmapped=True):
+        int_field: int = 0
+        str_field: str = ""
     """
+    def __init_subclass__(cls, ignore_unmapped=False):
+        setattr(cls, _IGNORE_UNMAPPED_KEY, ignore_unmapped)
+
     @staticmethod
     def encode_archive(obj, archive):
         for field in dataclasses.fields(type(obj)):


### PR DESCRIPTION
This PR adds a class parameter `ignore_missing` via [__init_subclass__](https://docs.python.org/3/reference/datamodel.html#object.__init_subclass__).
It allows the use of incomplete dataclasses, when the user is only interested in certain fields.
```python
class Model(DataclassArchiver, ignore_missing=True):
    field1: int = 0
```